### PR TITLE
fix(doc): broken link for Project-based Notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This public repository is designed to help students in SWEN90009 subject.
 
 ## [Sprints' Checklists](https://github.com/SWEN90009-2023/swen90009-2023-resources/tree/main/checklists)
 
-## [Project-based Notes](https://cis-projects.github.io/project_based_course_notes/chapter_0/introduction.html)
+## [Project-based Notes](https://cis-projects.github.io/project_based_course_notes/introduction.html)
 
 ## [SWEN90009 FAQ](https://wiggly-turnip-06b.notion.site/31ce10d52fd448258e5de1c29f4abb4e?v=acad4a40b114413b891fa94c4e1f85ef)
 


### PR DESCRIPTION
I found a broken link for _**Project-based Notes**_ in README.md. I thought to just fix it instead of pointing it out.

PS: I could not find any guidelines to contribute to this repository, so I just did it my way. Hope this is fine :)